### PR TITLE
Ensure support is always defined first when running tests.

### DIFF
--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -14,6 +14,8 @@ src_files:
     - vendor/jquery.js
     - vendor/underscore.js
     - vendor/backbone.js
+    - lib/assets/javascripts/backbone-support.js
+    - lib/assets/javascripts/backbone-support/support.js
     - lib/**/*.js
 
 # spec_files


### PR DESCRIPTION
The tests were failing for me because Support wasn't being defined first.
