### PR TITLE
CompositeView.renderChildInto wouldn't work unless the target was part of the document

### DIFF
--- a/lib/assets/javascripts/backbone-support/composite_view.js
+++ b/lib/assets/javascripts/backbone-support/composite_view.js
@@ -29,7 +29,7 @@ _.extend(Support.CompositeView.prototype, Backbone.View.prototype, {
   
   appendChildTo: function (view, container) {
     this.renderChild(view);
-    $(container).append(view.el);
+    this.$(container).append(view.el);
   },
   
   prependChild: function(view) {

--- a/spec/javascripts/composite_view_spec.js
+++ b/spec/javascripts/composite_view_spec.js
@@ -74,12 +74,22 @@ describe("Support.CompositeView", function() {
   describe("#appendChildTo", function() {
     it("appends child into the given element", function() {
       $("#test1").text("Append to this!");
-  
+      $("#test").append($("#test1"));
+
       var view = new blankView({el: "#test"});
       view.appendChildTo(new orangeView(), "#test1");
-  
-      expect($("#test").text()).toEqual("");
+
       expect($("#test1").text()).toEqual("Append to this!Orange!");
+      
+      $("#test1").remove();
+      expect($("#test").text()).toEqual("");
+    });
+
+    it("appends child into a sub-element even if it is not added to the document", function() {
+      var view = new blankView({el: $('<div><div class="inside">Append to this!</div></div>')});
+      view.appendChildTo(new orangeView(), ".inside");
+
+      expect($(view.el).find('.inside').text()).toEqual("Append to this!Orange!"); 
     });
   });
   


### PR DESCRIPTION
Changed it to use Backbone.View.$ instead of plain jQuery which is document-dependant. Specs are also updated (although the SwappingRouter ones were already failing on master) with an extra test case that illustrates what is fixed.
