### PR TITLE
Updates

### DIFF
--- a/lib/assets/javascripts/backbone-support/composite_view.js
+++ b/lib/assets/javascripts/backbone-support/composite_view.js
@@ -21,7 +21,7 @@ _.extend(Support.CompositeView.prototype, Backbone.View.prototype, Support.Obser
   
   renderChildInto: function(view, container) {
     this.renderChild(view);
-    this.$(container).empty().append(view.el);
+    this.$(container).html(view.el);
   },
 
   appendChild: function(view) {

--- a/lib/assets/javascripts/backbone-support/swapping_router.js
+++ b/lib/assets/javascripts/backbone-support/swapping_router.js
@@ -9,7 +9,7 @@ _.extend(Support.SwappingRouter.prototype, Backbone.Router.prototype, {
     }
 
     this.currentView = newView;
-    $(this.el).empty().append(this.currentView.render().el);
+    $(this.el).html(this.currentView.render().el);
 
     if (this.currentView && this.currentView.swapped) {
       this.currentView.swapped();


### PR DESCRIPTION
- Uses a View's cached `this.$el` instead of `$(this.el)`
- Uses jQuery's #html instead of #empty and #append
