### PR TITLE
Extend

### DIFF
--- a/lib/assets/javascripts/backbone-support/composite_view.js
+++ b/lib/assets/javascripts/backbone-support/composite_view.js
@@ -1,9 +1,9 @@
-Support.CompositeView = function(options) {
-  this.children = _([]);
-  Backbone.View.apply(this, [options]);
-};
+Support.CompositeView = Backbone.View.extend({
+  constructor: function(options) {
+    this.children = _([]);
+    Backbone.View.call(this, options);
+  },
 
-_.extend(Support.CompositeView.prototype, Backbone.View.prototype, Support.Observer.prototype, {
   leave: function() {
     this.trigger('leave');
     this.unbind();
@@ -66,4 +66,4 @@ _.extend(Support.CompositeView.prototype, Backbone.View.prototype, Support.Obser
   }
 });
 
-Support.CompositeView.extend = Backbone.View.extend;
+_.extend(Support.CompositeView.prototype, Support.Observer.prototype);

--- a/lib/assets/javascripts/backbone-support/swapping_router.js
+++ b/lib/assets/javascripts/backbone-support/swapping_router.js
@@ -1,8 +1,4 @@
-Support.SwappingRouter = function(options) {
-  Backbone.Router.apply(this, [options]);
-};
-
-_.extend(Support.SwappingRouter.prototype, Backbone.Router.prototype, {
+Support.SwappingRouter = Backbone.Router.extend({
   swap: function(newView) {
     if (this.currentView && this.currentView.leave) {
       this.currentView.leave();
@@ -16,5 +12,3 @@ _.extend(Support.SwappingRouter.prototype, Backbone.Router.prototype, {
     }
   }
 });
-
-Support.SwappingRouter.extend = Backbone.Router.extend;

--- a/spec/javascripts/composite_view_spec.js
+++ b/spec/javascripts/composite_view_spec.js
@@ -262,4 +262,11 @@ describe("Support.CompositeView", function() {
       expect(eventListener.called).toBeTruthy();
     });
   });
+
+  describe("class", function() {
+    it("respects instanceof", function() {
+      var view = new Support.CompositeView;
+      expect(view instanceof Backbone.View).toBeTruthy();
+    })
+  });
 });

--- a/spec/javascripts/swapping_router_spec.js
+++ b/spec/javascripts/swapping_router_spec.js
@@ -116,4 +116,8 @@ describe("Support.SwappingRouter", function() {
       done();
     });
   });
+
+  it("is instanceof Router", function() {
+    expect(router instanceof Backbone.Router).toBeTruthy();
+  });
 });


### PR DESCRIPTION
This uses Backbone's native .extend methods to define our custom subclasses.

Specifically, it cleans up SwappingRouter's code quite a bit. I've also converted CompositeView to use the same syntax, but it's not considerably better because it has a custom constructor and it needs Observer's mixins.