### PR TITLE
Backbone's #listenTo

### DIFF
--- a/lib/assets/javascripts/backbone-support/observer.js
+++ b/lib/assets/javascripts/backbone-support/observer.js
@@ -2,15 +2,10 @@ Support.Observer = function() {};
 
 _.extend(Support.Observer.prototype, {
   bindTo: function(source, event, callback) {
-    source.bind(event, callback, this);
-    this.bindings = this.bindings || [];
-    this.bindings.push({ source: source, event: event, callback: callback });
+    this.listenTo(source, event, callback);
   },
 
   unbindFromAll: function() {
-    _.each(this.bindings, function(binding) {
-      binding.source.unbind(binding.event, binding.callback);
-    });
-    this.bindings = []
+    this.stopListening();
   }
 });

--- a/lib/assets/javascripts/backbone-support/observer.js
+++ b/lib/assets/javascripts/backbone-support/observer.js
@@ -2,10 +2,12 @@ Support.Observer = function() {};
 
 _.extend(Support.Observer.prototype, {
   bindTo: function(source, event, callback) {
+    console.warn('Using #bindTo has been deprecated. Use #listenTo instead.');
     this.listenTo(source, event, callback);
   },
 
   unbindFromAll: function() {
+    console.warn('Using #unbindFromAll has been deprecated. Use #stopListening instead.');
     this.stopListening();
   }
 });

--- a/spec/javascripts/composite_view_spec.js
+++ b/spec/javascripts/composite_view_spec.js
@@ -258,19 +258,6 @@ describe("Support.CompositeView", function() {
     });
   });
 
-  describe("#bindTo", function() {
-    var view = new orangeView();
-    var callback = sinon.spy();
-    var source = new Backbone.Model({
-        title: 'Model or Collection'
-    });
-
-    it("calls the unbindFromAll method when leaving the view", function() {
-      view.bindTo(source, 'foobar', callback);
-      expect(view.bindings.length).toEqual(1);
-    });
-  });
-
   describe("#unbindFromAll", function() {
     var view = new orangeView();
     var spy = sinon.spy(view, 'unbindFromAll');

--- a/spec/javascripts/composite_view_spec.js
+++ b/spec/javascripts/composite_view_spec.js
@@ -269,7 +269,6 @@ describe("Support.CompositeView", function() {
     runs(function() {
       view.render();
       view.bindTo(source, 'foo', callback);
-      expect(view.bindings.length).toEqual(1);
     });
 
     Helpers.sleep();

--- a/spec/javascripts/observer_spec.js
+++ b/spec/javascripts/observer_spec.js
@@ -24,7 +24,7 @@ describe('Support.Observer', function() {
     var view, spy, source, callback;
     beforeEach(function() { Helpers.setup();
       view = new normalView();
-      spy = sinon.spy(view, "bindTo");
+      spy = sinon.spy(view, "listenTo");
       callback = sinon.spy();
 
       source = new Backbone.Model({
@@ -36,17 +36,9 @@ describe('Support.Observer', function() {
       view, spy, source, callback = null;
     });
 
-    it("should add the event to the bindings for the view", function() {
-      view.bindTo(source, 'foobar', callback);
-      expect(view.bindings.length).toEqual(1);
-    });
-
-    it("binds the event to the source object", function() {
-      var mock = sinon.mock(source).expects('bind').once();
-
+    it("call listenTo on this", function() {
       view.bindTo(source, 'change:title', callback);
-
-      mock.verify();
+      expect(spy.called).toBeTruthy();
     });
   });
 
@@ -55,17 +47,16 @@ describe('Support.Observer', function() {
     beforeEach(function() {
       view = new normalView();
       spy = sinon.spy(view, 'unbindFromAll');
+      stopListeningSpy = sinon.spy(view, 'stopListening');
       callback = sinon.spy();
       source = new Backbone.Model({
         title: 'Model or Collection'
       });
-      unbindSpy = sinon.spy(source, 'unbind');
 
       runs(function() {
         view.render();
         view.bindTo(source, 'foo', callback);
         view.bindTo(source, 'bar', callback);
-        expect(view.bindings.length).toEqual(2);
       });
 
       Helpers.sleep();
@@ -83,15 +74,9 @@ describe('Support.Observer', function() {
       });
     });
 
-    it("calls unbind on the source object", function() {
+    it("calls stopListening on this", function() {
       runs(function() {
-        expect(unbindSpy.calledTwice).toBeTruthy();
-      });
-    });
-
-    it("removes all the views bindings attached with bindTo", function() {
-      runs(function() {
-        expect(view.bindings.length).toEqual(0);
+        expect(stopListeningSpy.called).toBeTruthy();
       });
     });
   });

--- a/spec/javascripts/observer_spec.js
+++ b/spec/javascripts/observer_spec.js
@@ -36,7 +36,7 @@ describe('Support.Observer', function() {
       view, spy, source, callback = null;
     });
 
-    it("call listenTo on this", function() {
+    it("calls listenTo on this", function() {
       view.bindTo(source, 'change:title', callback);
       expect(spy.called).toBeTruthy();
     });


### PR DESCRIPTION
Backbone 0.9 introduced #listenTo and #stopListening methods that are equivalent to our #bindTo and #unbindFromAll. Delegate from our methods to Backbone's native methods for backwards compatibility.