### PR TITLE
Set parent before render

### DIFF
--- a/lib/assets/javascripts/backbone-support/composite_view.js
+++ b/lib/assets/javascripts/backbone-support/composite_view.js
@@ -14,9 +14,9 @@ _.extend(Support.CompositeView.prototype, Backbone.View.prototype, Support.Obser
   },
 
   renderChild: function(view) {
+    view.parent = this;
     view.render();
     this.children.push(view);
-    view.parent = this;
   },
 
   renderChildInto: function(view, container) {

--- a/spec/javascripts/composite_view_spec.js
+++ b/spec/javascripts/composite_view_spec.js
@@ -38,6 +38,24 @@ describe("Support.CompositeView", function() {
       expect($("#test1").text()).toEqual("Orange!");
       expect($("#test2").text()).toEqual("Orange!");
     });
+
+    it("sets parent before rendering child view", function() {
+      var view = new blankView();
+      var spy = sinon.spy(view, 'on');
+      var viewWithParentBinding = Support.CompositeView.extend({
+        render: function() {
+          this.listenTo(this.parent, 'foo', this.foo);
+          return this;
+        },
+
+        foo: function() {
+        }
+      });
+
+      view.renderChild(new viewWithParentBinding({ el: "#test1" }));
+
+      expect(spy.called).toBeTruthy();
+    });
   });
 
   describe("#renderChildInto", function() {


### PR DESCRIPTION
Allows the child view to have access to the parent when rendering so the
child can more easily bind to events on the parent. Alternatives include
manually passing in the parent view when initializing the view (which is
redundant) or having the parent setup the child view's listeners.

Included some whitespace and syntax cleanup for in the files that were
modified, but in a separate commit from the change in functionality.
